### PR TITLE
Python 3 fix - interpolated bytes/unicode string.

### DIFF
--- a/wavfile.py
+++ b/wavfile.py
@@ -188,7 +188,7 @@ def read(file, readmarkers=False, readmarkerlabels=False, readloops=False, readp
                 cuepointid, type, start, end, fraction, playcount = struct.unpack('<iiiiii', str1) 
                 loops.append([start,end]) 
         else:
-            warnings.warn("Chunk " + chunk_id + " skipped", WavFileWarning)
+            warnings.warn("Chunk {} skipped".format(chunk_id.decode('ascii')), WavFileWarning)
             _skip_unknown_chunk(fid)
     fid.close()
 


### PR DESCRIPTION
In Python 3 trying to run the main script raised a TypeError. This fixes that issue so the script works in Python 3 (without breaking it in Python 2.7).

Error:
```
Traceback (most recent call last):
  File "impulseresponse.py", line 26, in <module>
    sr, b, br = wavfile.read(RECFILE, normalized=True)
  File "/home/david/Documents/PythonProjects/impulseresponse_original/wavfile.py", line 191, in read
    warnings.warn("Chunk " + chunk_id + " skipped", WavFileWarning)
TypeError: must be str, not bytes
```